### PR TITLE
feat(buildkitd): lifecycle and terminationGracePeriodSeconds

### DIFF
--- a/charts/buildkitd/templates/statefulset.yaml
+++ b/charts/buildkitd/templates/statefulset.yaml
@@ -139,6 +139,10 @@ spec:
             {{- with .Values.extraSecurityContext }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/charts/buildkitd/templates/statefulset.yaml
+++ b/charts/buildkitd/templates/statefulset.yaml
@@ -158,6 +158,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   volumeClaimTemplates:
     - kind: PersistentVolumeClaim
       apiVersion: v1

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -108,3 +108,5 @@ startupProbe:
   retries: 60
 
 extraSecurityContext: {}
+
+lifecycle: {}

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -110,3 +110,6 @@ startupProbe:
 extraSecurityContext: {}
 
 lifecycle: {}
+
+terminationGracePeriodSeconds: 30
+


### PR DESCRIPTION
lifecycle is useful for running a pre-stop hook to make sure all build jobs can run to completion before terminating the pod
terminationGracePeriodSeconds is useful for making sure lifecycle pre-stop hook has enough time to complete