### PR TITLE
feat(buildkitd): hpa

### DIFF
--- a/charts/buildkitd/templates/hpa.yaml
+++ b/charts/buildkitd/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "buildkitd.fullname" . }}
+  labels:
+    {{- include "buildkitd.selectorLlabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "buildkitd.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/buildkitd/templates/hpa.yaml
+++ b/charts/buildkitd/templates/hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "buildkitd.fullname" . }}
   labels:
-    {{- include "buildkitd.selectorLlabels" . | nindent 4 }}
+    {{- include "buildkitd.selectorLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/buildkitd/templates/statefulset.yaml
+++ b/charts/buildkitd/templates/statefulset.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "buildkitd.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   serviceName: {{ include "buildkitd.fullname" . }}
   selector:
     matchLabels:

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -113,3 +113,9 @@ lifecycle: {}
 
 terminationGracePeriodSeconds: 30
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80


### PR DESCRIPTION
add a horizontal pod autoscaler. useful for scaling up when builder is overloaded. use with lifecycle pre-stop hook and a corresponding termination grace period to make sure builds complete before scaling down